### PR TITLE
Improve logo contrast

### DIFF
--- a/static/css/style.orange.css
+++ b/static/css/style.orange.css
@@ -2914,6 +2914,9 @@ fieldset[disabled] .btn-template-primary.active {
   line-height: 20px;
   height: 62px;
 }
+.navbar-brand img {
+  filter: drop-shadow(0 0 20px #fbcf80);
+}
 .navbar-brand:hover,
 .navbar-brand:focus {
   text-decoration: none;


### PR DESCRIPTION
The BreizhCamp logo is the same color as the header.

Add a light shadow to improve the contrast (see before / after)

<img width="885" alt="logo-breizhcamp" src="https://github.com/breizhcamp/website/assets/493223/fa616469-bbfc-4c23-8798-d2a2ae39e404">
